### PR TITLE
CAMEL-10141 Salesforce Maven Plugin POM cleanup

### DIFF
--- a/components/camel-salesforce/camel-salesforce-maven-plugin/pom.xml
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/pom.xml
@@ -175,15 +175,6 @@
       <!-- maven-jar-plugin config for Maven plugins. -->
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>bundle-jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <archive combine.self="override">
             <manifestFile/>
@@ -193,6 +184,41 @@
             </manifest>
           </archive>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>versions</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-package-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>validate</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>readme</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
       </plugin>
 
       <!-- Generate plugin help -->


### PR DESCRIPTION
Hey @johnpoth I think this might help with the `camel-salesforce-maven-plugin`.
I've disabled execution of `maven-bundle-plugin` and `camel-package-maven-plugin` which interfered with `maven-jar-plugin` -- they are not needed for building Maven plugins.